### PR TITLE
fix: handle symlinks in gitignore test setup

### DIFF
--- a/internal/tool/gitignore_test.go
+++ b/internal/tool/gitignore_test.go
@@ -437,10 +437,18 @@ func TestGetRepoRoot_CWDKeyedCache(t *testing.T) {
 
 	// Create two separate git repos with different .gitignore rules
 	repo1 := t.TempDir()
+	repo1, err = filepath.EvalSymlinks(repo1)
+	if err != nil {
+		t.Fatal(err)
+	}
 	os.MkdirAll(filepath.Join(repo1, ".git"), 0755)
 	os.WriteFile(filepath.Join(repo1, ".gitignore"), []byte("*.log\n"), 0644)
 
 	repo2 := t.TempDir()
+	repo2, err = filepath.EvalSymlinks(repo2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	os.MkdirAll(filepath.Join(repo2, ".git"), 0755)
 	os.WriteFile(filepath.Join(repo2, ".gitignore"), []byte("*.tmp\n"), 0644)
 


### PR DESCRIPTION
## Problem

The `TestGetRepoRoot_CWDKeyedCache` test can fail on systems where `t.TempDir()` returns a path containing symlinks (e.g., macOS where `/tmp` is a symlink). 

The `getRepoRoot()` function caches results keyed by the resolved repository root path. When `t.TempDir()` returns a symlinked path, the cache key doesn't match the actual resolved path, causing test flakiness.

## Solution

This PR adds `filepath.EvalSymlinks()` calls to both `repo1` and `repo2` paths in the test setup, ensuring the paths used for cache keying match the resolved filesystem paths.

## Changes

- `internal/tool/gitignore_test.go`: Added `filepath.EvalSymlinks()` resolution for both temporary repository directories in `TestGetRepoRoot_CWDKeyedCache`.

## Testing

- `make test` passes
- `go vet ./...` passes


### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [x] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](https://github.com/mlhher/late/blob/main/.github/CLA.md) in this repository.** *(To check the box, put an `x` between the brackets like this: `[x]`)*