### PR TITLE
Feat/subagent history

### DIFF
--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -80,6 +80,7 @@ func main() {
 	}
 
 	var loadedHistoryPath string
+	var loadedSessionMeta *session.SessionMeta
 	if *continueReq {
 		meta, err := session.GetLatestSession()
 		if err != nil {
@@ -93,12 +94,14 @@ func main() {
 		fmt.Printf("Resuming session: %s (%s)\n", meta.ID, meta.Title)
 		time.Sleep(500 * time.Millisecond) // Give user a moment to see what's happening
 		loadedHistoryPath = meta.HistoryPath
+		loadedSessionMeta = meta
 	} else if flag.NArg() > 0 && flag.Arg(0) == "session" {
-		path, _, shouldExit := handleSessionCommand(flag.Args()[1:])
-		if shouldExit {
+		sessCmdResult := handleSessionCommand(flag.Args()[1:])
+		if sessCmdResult.ShouldExit {
 			return
 		}
-		loadedHistoryPath = path
+		loadedHistoryPath = sessCmdResult.HistoryPath
+		loadedSessionMeta = sessCmdResult.Meta
 	}
 
 	if flag.NArg() > 0 && flag.Arg(0) == "worktree" {
@@ -218,14 +221,19 @@ func main() {
 		}
 	}
 
-	// Resolve subagent history persistence opt-in (explicit CLI flag > config file).
+	// Resolve subagent history persistence opt-in
+	// (explicit CLI flag > saved session preference > config file).
 	saveSubagentHistoriesCLI := false
 	flag.Visit(func(f *flag.Flag) {
 		if f.Name == "save-subagent-histories" {
 			saveSubagentHistoriesCLI = true
 		}
 	})
-	saveSubagentHistories := appconfig.ResolveSaveSubagentHistories(appConfig, saveSubagentHistoriesCLI, *saveSubagentHistoriesReq)
+	var storedSubagentHistoryPreference *bool
+	if loadedSessionMeta != nil {
+		storedSubagentHistoryPreference = loadedSessionMeta.SaveSubagentHistories
+	}
+	saveSubagentHistories := appconfig.ResolveSaveSubagentHistories(appConfig, saveSubagentHistoriesCLI, *saveSubagentHistoriesReq, storedSubagentHistoryPreference)
 
 	// Initialize Core Components
 	resolvedOpenAIConfig := appconfig.ResolveOpenAISettings(appConfig)
@@ -276,6 +284,11 @@ func main() {
 	mainTools["target_edit"] = false
 
 	sess := session.New(c, historyPath, history, systemPrompt, *useToolsReq)
+	if loadedSessionMeta != nil {
+		sess.SetSubagentMetadata(loadedSessionMeta.SubagentSeq, loadedSessionMeta.SaveSubagentHistories)
+	} else {
+		sess.SetSubagentMetadata(0, &saveSubagentHistories)
+	}
 	executor.RegisterTools(sess.Registry, mainTools)
 
 	// Register MCP tools into the session registry.
@@ -443,9 +456,14 @@ func newModelClient(ctx context.Context, setting appconfig.ModelSetting, enableI
 	return c
 }
 
-// handleSessionCommand processes session subcommands
-// Returns: command, args (remaining), verbose flag
-func handleSessionCommand(args []string) (string, []string, bool) {
+type sessionCommandResult struct {
+	HistoryPath string
+	Meta        *session.SessionMeta
+	ShouldExit  bool
+}
+
+// handleSessionCommand processes session subcommands.
+func handleSessionCommand(args []string) sessionCommandResult {
 	if len(args) == 0 {
 		fmt.Println("Usage: late session <list|load|delete> [args...]")
 		fmt.Println("")
@@ -453,7 +471,7 @@ func handleSessionCommand(args []string) (string, []string, bool) {
 		fmt.Println("  list [-v]      List all saved sessions (use -v for verbose/detailed view)")
 		fmt.Println("  load <id>      Load a session by ID (can use prefix)")
 		fmt.Println("  delete <id>    Delete a session by ID")
-		return "", nil, false
+		return sessionCommandResult{}
 	}
 
 	// Parse flags for specific commands
@@ -481,14 +499,15 @@ func handleSessionCommand(args []string) (string, []string, bool) {
 	switch args[0] {
 	case "list":
 		handleSessionList(verbose)
-		return "", nil, true
+		return sessionCommandResult{ShouldExit: true}
 	case "load":
 		if len(commandArgs) < 1 {
 			fmt.Println("Error: session ID required")
 			fmt.Println("Usage: late session load <id>")
 			os.Exit(1)
 		}
-		return handleSessionLoad(commandArgs[0]), nil, false
+		meta := handleSessionLoad(commandArgs[0])
+		return sessionCommandResult{HistoryPath: meta.HistoryPath, Meta: meta}
 	case "delete":
 		if len(commandArgs) < 1 {
 			fmt.Println("Error: session ID required")
@@ -496,11 +515,11 @@ func handleSessionCommand(args []string) (string, []string, bool) {
 			os.Exit(1)
 		}
 		handleSessionDelete(commandArgs[0])
-		return "", nil, true
+		return sessionCommandResult{ShouldExit: true}
 	default:
 		fmt.Printf("Unknown session command: %s\n", args[0])
 		handleSessionCommand([]string{})
-		return "", nil, true
+		return sessionCommandResult{ShouldExit: true}
 	}
 }
 
@@ -526,8 +545,8 @@ func handleSessionList(verbose bool) {
 	fmt.Println(session.FormatResumePrompt())
 }
 
-// handleSessionLoad returns the history path for the given session ID
-func handleSessionLoad(id string) string {
+// handleSessionLoad returns metadata for the given session ID.
+func handleSessionLoad(id string) *session.SessionMeta {
 	meta, err := session.LoadSessionMeta(id)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error loading session: %v\n", err)
@@ -542,7 +561,7 @@ func handleSessionLoad(id string) string {
 
 	fmt.Printf("Resuming session: %s (%s)\n", meta.ID, meta.Title)
 	time.Sleep(500 * time.Millisecond) // Give user a moment to see what's happening
-	return meta.HistoryPath
+	return meta
 }
 
 // handleSessionDelete removes a session

--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -178,8 +178,10 @@ func main() {
 	// Effective session ID for this run — derived from the FINAL history path so
 	// resumed sessions keep their original ID (the sessionID var above is a fresh
 	// timestamp even on resume). Used to place subagent histories under the right
-	// per-session folder.
-	effectiveSessionID := strings.TrimSuffix(filepath.Base(historyPath), ".json")
+	// per-session folder. The helper falls back to "" for empty or unsafe IDs,
+	// which disables subagent history persistence (in-memory fallback) instead of
+	// writing files outside the session folder.
+	effectiveSessionID := deriveEffectiveSessionID(historyPath)
 
 	// Load existing history
 	history, err := session.LoadHistory(historyPath)
@@ -403,6 +405,19 @@ func main() {
 		fmt.Printf("Unspecified error: %v", err)
 		os.Exit(1)
 	}
+}
+
+// deriveEffectiveSessionID derives this run's session ID from the FINAL
+// history path so resumed sessions keep their original ID. It returns ""
+// for empty or unsafe results (a crafted meta file could claim an ID like
+// ".."), which disables subagent history persistence for the run
+// (in-memory fallback) instead of writing files outside the session folder.
+func deriveEffectiveSessionID(historyPath string) string {
+	id := strings.TrimSuffix(filepath.Base(historyPath), ".json")
+	if id == "" || id == "." || id == ".." {
+		return ""
+	}
+	return id
 }
 
 func mcpToolEnabled(t tool.Tool, enabledTools map[string]bool) bool {

--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -582,7 +582,7 @@ func handleSessionDelete(id string) {
 	// legacy flat sessions without a folder. Non-fatal: the session itself is already
 	// gone, so don't block the success message on leftover artifacts.
 	if err := session.RemoveSessionFolder(meta.ID); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to delete subagent history folder: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: Failed to delete subagent history folder: %v\n", err)
 	}
 
 	fmt.Printf("Deleted session: %s\n", meta.Title)

--- a/cmd/late/main.go
+++ b/cmd/late/main.go
@@ -39,6 +39,7 @@ func main() {
 	enableSubagentsReq := flag.Bool("enable-subagents", true, "Enable subagent usage")
 	gemmaThinkingReq := flag.Bool("gemma-thinking", false, "Prepend <|think|> token to system prompt for Gemma 4 models")
 	subagentMaxTurns := flag.Int("subagent-max-turns", 500, "Maximum number of turns for subagents (default: 500)")
+	saveSubagentHistoriesReq := flag.Bool("save-subagent-histories", false, "Persist subagent conversation histories to disk (default: off)")
 	enableSqzReq := flag.Bool("enable-sqz", false, "Enable sqz context compression (if available)")
 	appendSystemPromptReq := flag.String("append-system-prompt", "", "Append text to the system prompt after processing")
 	versionReq := flag.Bool("version", false, "Show version")
@@ -174,6 +175,12 @@ func main() {
 		historyPath = loadedHistoryPath
 	}
 
+	// Effective session ID for this run — derived from the FINAL history path so
+	// resumed sessions keep their original ID (the sessionID var above is a fresh
+	// timestamp even on resume). Used to place subagent histories under the right
+	// per-session folder.
+	effectiveSessionID := strings.TrimSuffix(filepath.Base(historyPath), ".json")
+
 	// Load existing history
 	history, err := session.LoadHistory(historyPath)
 	if err != nil {
@@ -208,6 +215,15 @@ func main() {
 			enabledTools[toolName] = enabled
 		}
 	}
+
+	// Resolve subagent history persistence opt-in (explicit CLI flag > config file).
+	saveSubagentHistoriesCLI := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "save-subagent-histories" {
+			saveSubagentHistoriesCLI = true
+		}
+	})
+	saveSubagentHistories := appconfig.ResolveSaveSubagentHistories(appConfig, saveSubagentHistoriesCLI, *saveSubagentHistoriesReq)
 
 	// Initialize Core Components
 	resolvedOpenAIConfig := appconfig.ResolveOpenAISettings(appConfig)
@@ -361,7 +377,7 @@ func main() {
 				currentSubagentClient = subagentClient
 			}
 
-			child, err := agent.NewSubagentOrchestrator(currentSubagentClient, goal, ctxFiles, agentType, enabledTools, *injectCWDReq, *gemmaThinkingReq, *subagentMaxTurns, rootAgent, p)
+			child, err := agent.NewSubagentOrchestrator(currentSubagentClient, goal, ctxFiles, agentType, enabledTools, *injectCWDReq, *gemmaThinkingReq, *subagentMaxTurns, effectiveSessionID, saveSubagentHistories, rootAgent, p)
 			if err != nil {
 				return "", err
 			}
@@ -545,6 +561,13 @@ func handleSessionDelete(id string) {
 	if err := os.Remove(meta.HistoryPath); err != nil {
 		fmt.Fprintf(os.Stderr, "Error deleting history: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Delete the session's subagent history folder (hierarchical layout). No-op for
+	// legacy flat sessions without a folder. Non-fatal: the session itself is already
+	// gone, so don't block the success message on leftover artifacts.
+	if err := session.RemoveSessionFolder(meta.ID); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to delete subagent history folder: %v\n", err)
 	}
 
 	fmt.Printf("Deleted session: %s\n", meta.Title)

--- a/cmd/late/main_test.go
+++ b/cmd/late/main_test.go
@@ -126,3 +126,49 @@ func TestHandleSessionDelete_LegacyFlatSession(t *testing.T) {
 	assertFileGone(t, metaC)
 	assertFileGone(t, historyC)
 }
+
+func TestDeriveEffectiveSessionID(t *testing.T) {
+	tests := []struct {
+		name        string
+		historyPath string
+		want        string
+	}{
+		{
+			name:        "plain session history file",
+			historyPath: "session-20260815-123456.json",
+			want:        "session-20260815-123456",
+		},
+		{
+			name:        "full path uses base name",
+			historyPath: "/tmp/sessions/session-abc.json",
+			want:        "session-abc",
+		},
+		{
+			name:        "parent directory reference",
+			historyPath: "..",
+			want:        "",
+		},
+		{
+			name:        "full path ending in parent directory",
+			historyPath: "/some/dir/..",
+			want:        "",
+		},
+		{
+			name:        "current directory reference",
+			historyPath: ".",
+			want:        "",
+		},
+		{
+			name:        "json suffix only",
+			historyPath: ".json",
+			want:        "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveEffectiveSessionID(tt.historyPath); got != tt.want {
+				t.Errorf("deriveEffectiveSessionID(%q) = %q, want %q", tt.historyPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/late/main_test.go
+++ b/cmd/late/main_test.go
@@ -3,7 +3,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"late/internal/client"
+	"late/internal/session"
 )
 
 type mcpToolStub struct {
@@ -28,4 +34,95 @@ func TestMCPToolEnabledSupportsBareNames(t *testing.T) {
 	if !mcpToolEnabled(testTool, map[string]bool{"list_files": false, testTool.name: true}) {
 		t.Fatal("namespaced setting did not override bare-name setting")
 	}
+}
+
+// writeTestSession creates a flat session in the injected sessions directory:
+// <dir>/<id>.json (history) and <dir>/<id>.meta.json. It returns both paths.
+func writeTestSession(t *testing.T, sessionsDir, id string) (metaPath, historyPath string) {
+	t.Helper()
+
+	historyPath = filepath.Join(sessionsDir, id+".json")
+	if err := session.SaveHistory(historyPath, []client.ChatMessage{
+		{Role: "user", Content: client.TextContent("hello")},
+	}); err != nil {
+		t.Fatalf("SaveHistory(%s): %v", id, err)
+	}
+
+	if err := session.SaveSessionMeta(session.SessionMeta{
+		ID:           id,
+		Title:        "Test session " + id,
+		CreatedAt:    time.Now(),
+		LastUpdated:  time.Now(),
+		HistoryPath:  historyPath,
+		MessageCount: 1,
+	}); err != nil {
+		t.Fatalf("SaveSessionMeta(%s): %v", id, err)
+	}
+
+	return filepath.Join(sessionsDir, id+".meta.json"), historyPath
+}
+
+// injectSessionDir points session.SessionDir at a temp dir for the test's duration.
+func injectSessionDir(t *testing.T) string {
+	t.Helper()
+
+	tmp := t.TempDir()
+	oldDir := session.SessionDir
+	session.SessionDir = func() (string, error) { return tmp, nil }
+	t.Cleanup(func() { session.SessionDir = oldDir })
+
+	return tmp
+}
+
+func assertFileGone(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be removed, but it still exists", path)
+	}
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s to still exist: %v", path, err)
+	}
+}
+
+func TestHandleSessionDelete_RemovesSubagentFolder(t *testing.T) {
+	tmp := injectSessionDir(t)
+
+	metaA, historyA := writeTestSession(t, tmp, "session-20250101-123456")
+	// Session A also has the hierarchical subagent history folder.
+	folderA := filepath.Join(tmp, "session-20250101-123456")
+	subagentsDir := filepath.Join(folderA, "subagents")
+	if err := os.MkdirAll(subagentsDir, 0700); err != nil {
+		t.Fatalf("creating subagent dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentsDir, "researcher-subagent-0.json"), []byte("[]"), 0600); err != nil {
+		t.Fatalf("writing subagent history: %v", err)
+	}
+
+	metaB, historyB := writeTestSession(t, tmp, "session-20250102-999999")
+
+	handleSessionDelete("session-20250101-123456")
+
+	// Session A: meta, history, and the entire subagent folder are all gone.
+	assertFileGone(t, metaA)
+	assertFileGone(t, historyA)
+	assertFileGone(t, folderA)
+
+	// Session B is untouched.
+	assertFileExists(t, metaB)
+	assertFileExists(t, historyB)
+}
+
+func TestHandleSessionDelete_LegacyFlatSession(t *testing.T) {
+	tmp := injectSessionDir(t)
+
+	metaC, historyC := writeTestSession(t, tmp, "session-20250103-000000")
+
+	handleSessionDelete("session-20250103-000000")
+
+	assertFileGone(t, metaC)
+	assertFileGone(t, historyC)
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -255,7 +255,7 @@ late session load <id>     # Resume a previous session
 late session delete <id>   # Delete a session
 ```
 
-By default, subagent conversations are kept in memory and discarded. With `--save-subagent-histories` (or `"save_subagent_histories": true` in the config file), each subagent's history is saved under the session folder — `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` — while the parent session files stay in place. `late session delete <id>` removes the subagent folder along with the session.
+By default, subagent conversations are kept in memory and discarded. With `--save-subagent-histories` (or `"save_subagent_histories": true` in the config file), each subagent's history is saved under the session folder — `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` — while the parent session files stay in place. `late session delete <id>` removes the subagent folder along with the session. Note that saved transcripts may contain sensitive content (file contents, tool outputs); they are written with user-only permissions.
 
 ## Git Worktrees
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -255,8 +255,6 @@ late session load <id>     # Resume a previous session
 late session delete <id>   # Delete a session
 ```
 
-By default, subagent conversations are kept in memory and discarded. With `--save-subagent-histories` (or `"save_subagent_histories": true` in the config file), each subagent's history is saved under the session folder — `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` — while the parent session files stay in place. `late session delete <id>` removes the subagent folder along with the session. Note that saved transcripts may contain sensitive content (file contents, tool outputs); they are written with user-only permissions.
-
 ## Git Worktrees
 
 Late is designed for parallel development. You can manage Git worktrees directly to run separate agent instances in isolated environments:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -242,6 +242,7 @@ You can also create an `.llmignore` file alongside your `.gitignore` to specific
 | `--subagent-max-turns <n>` | Set max turns per subagent (default: 500) |
 | `--append-system-prompt "..."` | Append text to the system prompt (e.g. further instructions) |
 | `--enable-images` | Treat models as supporting images (for none llama.cpp servers) |
+| `--save-subagent-histories` | Persist subagent conversation histories to disk. Off by default (subagent transcripts are large); can also be enabled via `save_subagent_histories` in the config file |
 
 ## Sessions
 
@@ -253,6 +254,8 @@ late session list -v       # Verbose listing with details
 late session load <id>     # Resume a previous session
 late session delete <id>   # Delete a session
 ```
+
+By default, subagent conversations are kept in memory and discarded. With `--save-subagent-histories` (or `"save_subagent_histories": true` in the config file), each subagent's history is saved under the session folder — `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` — while the parent session files stay in place. `late session delete <id>` removes the subagent folder along with the session.
 
 ## Git Worktrees
 

--- a/docs/quickstart.zh-CN.md
+++ b/docs/quickstart.zh-CN.md
@@ -253,8 +253,6 @@ late session load <id>     # 恢复指定的历史会话
 late session delete <id>   # 删除指定的会话
 ```
 
-默认情况下，子智能体的对话仅保存在内存中，结束后即被丢弃。使用 `--save-subagent-histories`（或在配置文件中设置 `"save_subagent_histories": true`）后，每个子智能体的对话历史记录都会被保存到会话文件夹下 —— `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` —— 而父会话的原始文件位置保持不变。运行 `late session delete <id>` 删除会话时，子智能体文件夹也会随之被一并移除。请注意，保存的对话记录可能包含敏感内容（文件内容、工具输出）；这些文件以仅限用户读取的权限写入。
-
 ## Git 工作树 (Git Worktrees)
 
 Late 是专为并行开发设计的。你可以直接管理 Git 工作树，从而在隔离的环境中运行多个独立的智能体实例：

--- a/docs/quickstart.zh-CN.md
+++ b/docs/quickstart.zh-CN.md
@@ -253,7 +253,7 @@ late session load <id>     # 恢复指定的历史会话
 late session delete <id>   # 删除指定的会话
 ```
 
-默认情况下，子智能体的对话仅保存在内存中，结束后即被丢弃。使用 `--save-subagent-histories`（或在配置文件中设置 `"save_subagent_histories": true`）后，每个子智能体的对话历史记录都会被保存到会话文件夹下 —— `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` —— 而父会话的原始文件位置保持不变。运行 `late session delete <id>` 删除会话时，子智能体文件夹也会随之被一并移除。
+默认情况下，子智能体的对话仅保存在内存中，结束后即被丢弃。使用 `--save-subagent-histories`（或在配置文件中设置 `"save_subagent_histories": true`）后，每个子智能体的对话历史记录都会被保存到会话文件夹下 —— `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` —— 而父会话的原始文件位置保持不变。运行 `late session delete <id>` 删除会话时，子智能体文件夹也会随之被一并移除。请注意，保存的对话记录可能包含敏感内容（文件内容、工具输出）；这些文件以仅限用户读取的权限写入。
 
 ## Git 工作树 (Git Worktrees)
 

--- a/docs/quickstart.zh-CN.md
+++ b/docs/quickstart.zh-CN.md
@@ -240,6 +240,7 @@ Late 的原生搜索工具会自动遵循你的项目 `.gitignore`，通过排�
 | `--subagent-max-turns <n>` | 设置每个子智能体的最大交互轮数 (默认：500) |
 | `--append-system-prompt "..."` | 向系统提示词的末尾追加文本（例如自定义的补充说明） |
 | `--enable-images` | 将模型视为支持图像（适用于非 llama.cpp 的服务器） |
+| `--save-subagent-histories` | 将子智能体的对话历史记录持久化保存到磁盘。默认关闭（子智能体转录内容较大）；也可以在配置文件中通过 `save_subagent_histories` 开启 |
 
 ## 会话管理 (Sessions)
 
@@ -251,6 +252,8 @@ late session list -v       # 列出详细信息的会话记录
 late session load <id>     # 恢复指定的历史会话
 late session delete <id>   # 删除指定的会话
 ```
+
+默认情况下，子智能体的对话仅保存在内存中，结束后即被丢弃。使用 `--save-subagent-histories`（或在配置文件中设置 `"save_subagent_histories": true`）后，每个子智能体的对话历史记录都会被保存到会话文件夹下 —— `~/.local/share/late/sessions/<session-id>/subagents/<type>-subagent-<N>.json` —— 而父会话的原始文件位置保持不变。运行 `late session delete <id>` 删除会话时，子智能体文件夹也会随之被一并移除。
 
 ## Git 工作树 (Git Worktrees)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -23,6 +23,8 @@ func NewSubagentOrchestrator(
 	injectCWD bool,
 	gemmaThinking bool,
 	maxTurns int,
+	parentSessionID string,
+	saveSubagentHistory bool,
 	parent common.Orchestrator,
 	messenger tui.Messenger,
 ) (common.Orchestrator, error) {
@@ -60,8 +62,27 @@ func NewSubagentOrchestrator(
 		systemPrompt = "<|think|>" + systemPrompt
 	}
 
-	// 2. Setup Subagent Session (Isolated History)
-	sess := session.New(c, "", []client.ChatMessage{}, systemPrompt, true)
+	// Mint the child ID up-front so it can be embedded in the subagent history path.
+	var id string
+	if p, ok := parent.(*orchestrator.BaseOrchestrator); ok {
+		id = p.NextChildID(agentType)
+	} else if parent != nil {
+		// Fallback for non-BaseOrchestrator parents (test fakes only).
+		id = fmt.Sprintf("%s-subagent-%d", agentType, len(parent.Children()))
+	} else {
+		id = fmt.Sprintf("%s-subagent-0", agentType)
+	}
+
+	// 2. Setup Subagent Session (Isolated History; persisted only when opted in)
+	var subagentHistoryPath string
+	if saveSubagentHistory && parentSessionID != "" {
+		path, err := session.SubagentHistoryPath(parentSessionID, id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve subagent history path: %w", err)
+		}
+		subagentHistoryPath = path
+	}
+	sess := session.NewSubagentSession(c, subagentHistoryPath, []client.ChatMessage{}, systemPrompt)
 
 	// Inherit all tools from parent (including MCP tools)
 	if parent != nil && parent.Registry() != nil {
@@ -101,7 +122,6 @@ func NewSubagentOrchestrator(
 	}
 
 	// 4. Create Orchestrator
-	id := fmt.Sprintf("%s-subagent-%d", agentType, len(parent.Children()))
 	mws := parent.Middlewares()
 
 	if messenger != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -62,16 +62,14 @@ func NewSubagentOrchestrator(
 		systemPrompt = "<|think|>" + systemPrompt
 	}
 
-	// Mint the child ID up-front so it can be embedded in the subagent history path.
-	var id string
-	if p, ok := parent.(*orchestrator.BaseOrchestrator); ok {
-		id = p.NextChildID(agentType)
-	} else if parent != nil {
-		// Fallback for non-BaseOrchestrator parents (test fakes only).
-		id = fmt.Sprintf("%s-subagent-%d", agentType, len(parent.Children()))
-	} else {
-		id = fmt.Sprintf("%s-subagent-0", agentType)
+	// Mint the child ID up-front so it can be embedded in the subagent history
+	// path. The parent must be a *BaseOrchestrator: its mutex-protected counter
+	// is the only ID source that cannot collide under concurrent spawns.
+	baseParent, ok := parent.(*orchestrator.BaseOrchestrator)
+	if !ok {
+		return nil, fmt.Errorf("subagent parent must be a *orchestrator.BaseOrchestrator")
 	}
+	id := baseParent.NextChildID(agentType)
 
 	// 2. Setup Subagent Session (Isolated History; persisted only when opted in)
 	var subagentHistoryPath string

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -42,6 +42,11 @@ func NewSubagentOrchestrator(
 	if config == nil {
 		return nil, fmt.Errorf("unknown agent type: %s", agentType)
 	}
+	if saveSubagentHistory && parentSessionID != "" {
+		if _, err := session.SubagentHistoryDir(parentSessionID); err != nil {
+			return nil, fmt.Errorf("failed to resolve subagent history path: %w", err)
+		}
+	}
 
 	content, err := assets.PromptsFS.ReadFile(config.PromptFile)
 	if err != nil {
@@ -69,7 +74,10 @@ func NewSubagentOrchestrator(
 	if !ok {
 		return nil, fmt.Errorf("subagent parent must be a *orchestrator.BaseOrchestrator")
 	}
-	id := baseParent.NextChildID(agentType)
+	id, err := baseParent.NextChildID(agentType)
+	if err != nil {
+		return nil, err
+	}
 
 	// 2. Setup Subagent Session (Isolated History; persisted only when opted in)
 	var subagentHistoryPath string

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -342,9 +342,11 @@ func TestNewSubagentOrchestrator_PersistsWhenOptedIn(t *testing.T) {
 		t.Errorf("Expected a message containing goal %q, got %d messages", goal, len(msgs))
 	}
 
-	// Meta-skip invariant: subagent sessions must never write .meta.json sidecars.
+	// The parent sequence reservation writes its root metadata sidecar. Subagent
+	// sessions themselves must never write nested .meta.json sidecars.
+	rootMetaPath := filepath.Join(tmp, "mock-session.meta.json")
 	for _, f := range walkRegularFiles(t, tmp) {
-		if strings.HasSuffix(f, ".meta.json") {
+		if strings.HasSuffix(f, ".meta.json") && f != rootMetaPath {
 			t.Errorf("Unexpected .meta.json file written by subagent session: %s", f)
 		}
 	}
@@ -426,8 +428,11 @@ func TestNewSubagentOrchestrator_InMemoryByDefault(t *testing.T) {
 		t.Fatalf("Failed to create subagent orchestrator: %v", err)
 	}
 
+	rootMetaPath := filepath.Join(tmp, "mock-session.meta.json")
 	for _, f := range walkRegularFiles(t, tmp) {
-		t.Errorf("Expected no regular files in session dir when saveSubagentHistory=false, found: %s", f)
+		if f != rootMetaPath {
+			t.Errorf("Expected only root metadata when saveSubagentHistory=false, found: %s", f)
+		}
 	}
 }
 
@@ -474,5 +479,57 @@ func TestNewSubagentOrchestrator_SecondSpawnGetsNextID(t *testing.T) {
 		if _, err := os.Stat(p); err != nil {
 			t.Errorf("Expected subagent history file %s to exist: %v", p, err)
 		}
+	}
+}
+
+func TestNewSubagentOrchestrator_ResumedParentUsesNextHistoryPath(t *testing.T) {
+	tmp := t.TempDir()
+	setSessionDirForTest(t, tmp)
+
+	c := client.NewClient(client.Config{BaseURL: "http://localhost:8080"})
+	historyPath := filepath.Join(tmp, "session-test.json")
+	saveHistories := true
+	parentSession := session.New(c, historyPath, nil, "mock system prompt", true)
+	parentSession.SetSubagentMetadata(0, &saveHistories)
+	parent := orchestrator.NewBaseOrchestrator("parent", parentSession, nil, 10)
+
+	first, err := NewSubagentOrchestrator(c, "first goal", nil, "researcher", map[string]bool{}, false, false, 10, "session-test", true, parent, nil)
+	if err != nil {
+		t.Fatalf("first NewSubagentOrchestrator() error = %v", err)
+	}
+	if first.ID() != "researcher-subagent-0" {
+		t.Fatalf("first child ID = %q, want researcher-subagent-0", first.ID())
+	}
+
+	firstHistoryPath := filepath.Join(tmp, "session-test", "subagents", "researcher-subagent-0.json")
+	firstHistory, err := os.ReadFile(firstHistoryPath)
+	if err != nil {
+		t.Fatalf("ReadFile(first child history) error = %v", err)
+	}
+
+	meta, err := session.LoadSessionMeta("session-test")
+	if err != nil {
+		t.Fatalf("LoadSessionMeta() error = %v", err)
+	}
+	resumedSession := session.New(c, historyPath, nil, "mock system prompt", true)
+	resumedSession.SetSubagentMetadata(meta.SubagentSeq, meta.SaveSubagentHistories)
+	resumedParent := orchestrator.NewBaseOrchestrator("parent", resumedSession, nil, 10)
+
+	second, err := NewSubagentOrchestrator(c, "second goal", nil, "coder", map[string]bool{}, false, false, 10, "session-test", true, resumedParent, nil)
+	if err != nil {
+		t.Fatalf("resumed NewSubagentOrchestrator() error = %v", err)
+	}
+	if second.ID() != "coder-subagent-1" {
+		t.Errorf("resumed child ID = %q, want coder-subagent-1", second.ID())
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "session-test", "subagents", "coder-subagent-1.json")); err != nil {
+		t.Errorf("second child history was not created: %v", err)
+	}
+	updatedFirstHistory, err := os.ReadFile(firstHistoryPath)
+	if err != nil {
+		t.Fatalf("ReadFile(first child history after resume) error = %v", err)
+	}
+	if string(updatedFirstHistory) != string(firstHistory) {
+		t.Error("resumed child creation overwrote the original child history")
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,8 +1,11 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"late/internal/client"
@@ -34,6 +37,8 @@ func TestNewSubagentOrchestratorWithGemmaThinking(t *testing.T) {
 		false, // injectCWD
 		true,  // gemmaThinking
 		100,   // maxTurns
+		"",    // parentSessionID
+		false, // saveSubagentHistory
 		parent,
 		nil, // messenger
 	)
@@ -66,6 +71,8 @@ func TestNewSubagentOrchestratorWithGemmaThinking(t *testing.T) {
 		false, // injectCWD
 		false, // gemmaThinking
 		100,   // maxTurns
+		"",    // parentSessionID
+		false, // saveSubagentHistory
 		parent,
 		nil, // messenger
 	)
@@ -107,9 +114,11 @@ func TestNewSubagentOrchestratorGemmaThinkingWithCWD(t *testing.T) {
 		[]string{},
 		"coder",
 		enabledTools,
-		true, // injectCWD
-		true, // gemmaThinking
-		100,  // maxTurns
+		true,  // injectCWD
+		true,  // gemmaThinking
+		100,   // maxTurns
+		"",    // parentSessionID
+		false, // saveSubagentHistory
 		parent,
 		nil, // messenger
 	)
@@ -165,6 +174,8 @@ func TestNewSubagentOrchestratorID(t *testing.T) {
 		false,
 		false,
 		100,
+		"",
+		false,
 		parent,
 		nil,
 	)
@@ -174,5 +185,249 @@ func TestNewSubagentOrchestratorID(t *testing.T) {
 
 	if !strings.Contains(child.ID(), "coder") {
 		t.Errorf("Expected child ID to contain 'coder', got %s", child.ID())
+	}
+}
+
+// TestNewSubagentOrchestrator_ConcurrentSpawn is the FR2 regression test:
+// concurrent spawns against a shared parent must never mint duplicate child IDs.
+func TestNewSubagentOrchestrator_ConcurrentSpawn(t *testing.T) {
+	cfg := client.Config{BaseURL: "http://localhost:8080"}
+	c := client.NewClient(cfg)
+
+	// Create a shared mock parent session and orchestrator
+	mockSession := session.New(c, "/tmp/mock-session.json", []client.ChatMessage{}, "mock system prompt", true)
+	parent := orchestrator.NewBaseOrchestrator("parent", mockSession, nil, 10)
+
+	const numSpawn = 16
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	ids := make([]string, 0, numSpawn)
+
+	for i := 0; i < numSpawn; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			child, err := NewSubagentOrchestrator(
+				c,
+				"goal",
+				nil,
+				"researcher",
+				map[string]bool{}, // enabledTools
+				false,             // injectCWD
+				false,             // gemmaThinking
+				10,                // maxTurns
+				"",                // parentSessionID
+				false,             // saveSubagentHistory
+				parent,
+				nil, // messenger
+			)
+			if err != nil {
+				t.Errorf("Failed to create subagent orchestrator: %v", err)
+				return
+			}
+
+			mu.Lock()
+			ids = append(ids, child.ID())
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(ids) != numSpawn {
+		t.Fatalf("Expected %d spawned orchestrators, got %d", numSpawn, len(ids))
+	}
+
+	// Assert all IDs are unique (no collisions)
+	seen := make(map[string]bool, numSpawn)
+	for _, id := range ids {
+		if seen[id] {
+			t.Errorf("Duplicate child ID minted by concurrent spawns: %s", id)
+		}
+		seen[id] = true
+	}
+
+	if n := len(parent.Children()); n != numSpawn {
+		t.Errorf("Expected parent to have %d children, got %d", numSpawn, n)
+	}
+}
+
+// setSessionDirForTest points session.SessionDir at dir for the duration of
+// the test, restoring the previous value on cleanup.
+func setSessionDirForTest(t *testing.T, dir string) {
+	t.Helper()
+	oldDir := session.SessionDir
+	session.SessionDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { session.SessionDir = oldDir })
+}
+
+// walkRegularFiles returns the paths of all regular files under root.
+func walkRegularFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk %s: %v", root, err)
+	}
+	return files
+}
+
+// TestNewSubagentOrchestrator_PersistsWhenOptedIn verifies that with
+// saveSubagentHistory=true the subagent's initial goal message is persisted to
+// <SessionDir()>/<parentSessionID>/subagents/<childID>.json, and that subagent
+// sessions never write a .meta.json sidecar.
+func TestNewSubagentOrchestrator_PersistsWhenOptedIn(t *testing.T) {
+	tmp := t.TempDir()
+	setSessionDirForTest(t, tmp)
+
+	cfg := client.Config{BaseURL: "http://localhost:8080"}
+	c := client.NewClient(cfg)
+
+	mockSession := session.New(c, "/tmp/mock-session.json", []client.ChatMessage{}, "mock system prompt", true)
+	parent := orchestrator.NewBaseOrchestrator("parent", mockSession, nil, 10)
+
+	const goal = "persist me"
+	_, err := NewSubagentOrchestrator(
+		c,
+		goal,
+		[]string{},
+		"researcher",
+		map[string]bool{}, // enabledTools
+		false,             // injectCWD
+		false,             // gemmaThinking
+		10,                // maxTurns
+		"session-test",    // parentSessionID
+		true,              // saveSubagentHistory
+		parent,
+		nil, // messenger
+	)
+	if err != nil {
+		t.Fatalf("Failed to create subagent orchestrator: %v", err)
+	}
+
+	historyPath := filepath.Join(tmp, "session-test", "subagents", "researcher-subagent-0.json")
+	if _, err := os.Stat(historyPath); err != nil {
+		t.Fatalf("Expected subagent history file %s to exist: %v", historyPath, err)
+	}
+
+	data, err := os.ReadFile(historyPath)
+	if err != nil {
+		t.Fatalf("Failed to read subagent history file: %v", err)
+	}
+
+	var msgs []client.ChatMessage
+	if err := json.Unmarshal(data, &msgs); err != nil {
+		t.Fatalf("Failed to unmarshal subagent history file: %v", err)
+	}
+	if len(msgs) < 1 {
+		t.Fatalf("Expected at least 1 message in subagent history, got %d", len(msgs))
+	}
+
+	foundGoal := false
+	for _, msg := range msgs {
+		if strings.Contains(msg.Content.String(), goal) {
+			foundGoal = true
+			break
+		}
+	}
+	if !foundGoal {
+		t.Errorf("Expected a message containing goal %q, got %d messages", goal, len(msgs))
+	}
+
+	// Meta-skip invariant: subagent sessions must never write .meta.json sidecars.
+	for _, f := range walkRegularFiles(t, tmp) {
+		if strings.HasSuffix(f, ".meta.json") {
+			t.Errorf("Unexpected .meta.json file written by subagent session: %s", f)
+		}
+	}
+}
+
+// TestNewSubagentOrchestrator_InMemoryByDefault verifies that with
+// saveSubagentHistory=false the subagent session is fully in-memory: nothing
+// (not even a directory artifact) is written to the session directory.
+func TestNewSubagentOrchestrator_InMemoryByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	setSessionDirForTest(t, tmp)
+
+	cfg := client.Config{BaseURL: "http://localhost:8080"}
+	c := client.NewClient(cfg)
+
+	mockSession := session.New(c, "/tmp/mock-session.json", []client.ChatMessage{}, "mock system prompt", true)
+	parent := orchestrator.NewBaseOrchestrator("parent", mockSession, nil, 10)
+
+	_, err := NewSubagentOrchestrator(
+		c,
+		"test goal",
+		[]string{},
+		"researcher",
+		map[string]bool{}, // enabledTools
+		false,             // injectCWD
+		false,             // gemmaThinking
+		10,                // maxTurns
+		"session-test",    // parentSessionID
+		false,             // saveSubagentHistory
+		parent,
+		nil, // messenger
+	)
+	if err != nil {
+		t.Fatalf("Failed to create subagent orchestrator: %v", err)
+	}
+
+	for _, f := range walkRegularFiles(t, tmp) {
+		t.Errorf("Expected no regular files in session dir when saveSubagentHistory=false, found: %s", f)
+	}
+}
+
+// TestNewSubagentOrchestrator_SecondSpawnGetsNextID verifies that two spawns
+// against the same parent mint distinct child IDs, producing two separate
+// history files (no overwrite/collision).
+func TestNewSubagentOrchestrator_SecondSpawnGetsNextID(t *testing.T) {
+	tmp := t.TempDir()
+	setSessionDirForTest(t, tmp)
+
+	cfg := client.Config{BaseURL: "http://localhost:8080"}
+	c := client.NewClient(cfg)
+
+	mockSession := session.New(c, "/tmp/mock-session.json", []client.ChatMessage{}, "mock system prompt", true)
+	parent := orchestrator.NewBaseOrchestrator("parent", mockSession, nil, 10)
+
+	const goal = "persist me"
+	spawn := func() {
+		_, err := NewSubagentOrchestrator(
+			c,
+			goal,
+			[]string{},
+			"researcher",
+			map[string]bool{}, // enabledTools
+			false,             // injectCWD
+			false,             // gemmaThinking
+			10,                // maxTurns
+			"session-test",    // parentSessionID
+			true,              // saveSubagentHistory
+			parent,
+			nil, // messenger
+		)
+		if err != nil {
+			t.Fatalf("Failed to create subagent orchestrator: %v", err)
+		}
+	}
+
+	spawn()
+	spawn()
+
+	subagentsDir := filepath.Join(tmp, "session-test", "subagents")
+	for _, name := range []string{"researcher-subagent-0.json", "researcher-subagent-1.json"} {
+		p := filepath.Join(subagentsDir, name)
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("Expected subagent history file %s to exist: %v", p, err)
+		}
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -350,6 +350,51 @@ func TestNewSubagentOrchestrator_PersistsWhenOptedIn(t *testing.T) {
 	}
 }
 
+// TestNewSubagentOrchestrator_RejectsUnsafeParentSessionID verifies that an
+// unsafe parentSessionID (e.g. "..") is rejected at history path resolution
+// before anything is written to the session directory (defense in depth;
+// Phase 2 makes this unreachable from production).
+func TestNewSubagentOrchestrator_RejectsUnsafeParentSessionID(t *testing.T) {
+	tmp := t.TempDir()
+	setSessionDirForTest(t, tmp)
+
+	cfg := client.Config{BaseURL: "http://localhost:8080"}
+	c := client.NewClient(cfg)
+
+	mockSession := session.New(c, "/tmp/mock-session.json", []client.ChatMessage{}, "mock system prompt", true)
+	parent := orchestrator.NewBaseOrchestrator("parent", mockSession, nil, 10)
+
+	const goal = "persist me"
+	_, err := NewSubagentOrchestrator(
+		c,
+		goal,
+		[]string{},
+		"coder",
+		map[string]bool{}, // enabledTools
+		false,             // injectCWD
+		false,             // gemmaThinking
+		10,                // maxTurns
+		"..",              // parentSessionID
+		true,              // saveSubagentHistory
+		parent,
+		nil, // messenger
+	)
+	if err == nil {
+		t.Fatalf("Expected error for unsafe parentSessionID, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to resolve subagent history path") {
+		t.Errorf("Expected error to contain %q, got: %v", "failed to resolve subagent history path", err)
+	}
+
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("Failed to read temp sessions dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected zero entries in temp sessions dir, got %d: %v", len(entries), entries)
+	}
+}
+
 // TestNewSubagentOrchestrator_InMemoryByDefault verifies that with
 // saveSubagentHistory=false the subagent session is fully in-memory: nothing
 // (not even a directory artifact) is written to the session directory.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,11 @@ type Config struct {
 	LateSubagentAPIKey  string          `json:"late_subagent_api_key,omitempty"`
 	LateSubagentModel   string          `json:"late_subagent_model,omitempty"`
 
+	// SaveSubagentHistories opts in to persisting subagent conversation
+	// histories under <sessions>/<session-id>/subagents/. Default false.
+	// Enable via config file or the --save-subagent-histories CLI flag.
+	SaveSubagentHistories bool `json:"save_subagent_histories,omitempty"`
+
 	// Legacy subagent fields for backward compatibility
 	SubagentBaseURL string `json:"subagent_base_url,omitempty"`
 	SubagentAPIKey  string `json:"subagent_api_key,omitempty"`
@@ -217,6 +222,19 @@ func ResolveSubagentSettingsWithEnv(cfg *Config, openAI OpenAISettings, lookup E
 	}
 
 	return resolved
+}
+
+// ResolveSaveSubagentHistories determines whether subagent history
+// persistence is enabled. Precedence: explicit CLI flag > config file.
+// There is intentionally no environment-variable override.
+func ResolveSaveSubagentHistories(cfg *Config, cliExplicit bool, cliValue bool) bool {
+	if cliExplicit {
+		return cliValue
+	}
+	if cfg != nil {
+		return cfg.SaveSubagentHistories
+	}
+	return false
 }
 
 func nonEmptyEnv(lookup EnvLookup, key string) (string, bool) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,11 +225,15 @@ func ResolveSubagentSettingsWithEnv(cfg *Config, openAI OpenAISettings, lookup E
 }
 
 // ResolveSaveSubagentHistories determines whether subagent history
-// persistence is enabled. Precedence: explicit CLI flag > config file.
-// There is intentionally no environment-variable override.
-func ResolveSaveSubagentHistories(cfg *Config, cliExplicit bool, cliValue bool) bool {
+// persistence is enabled. Precedence: explicit CLI flag > saved session
+// preference > config file. There is intentionally no environment-variable
+// override.
+func ResolveSaveSubagentHistories(cfg *Config, cliExplicit bool, cliValue bool, savedPreference *bool) bool {
 	if cliExplicit {
 		return cliValue
+	}
+	if savedPreference != nil {
+		return *savedPreference
 	}
 	if cfg != nil {
 		return cfg.SaveSubagentHistories

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -528,6 +528,60 @@ func TestResolveSubagentSettings(t *testing.T) {
 	}
 }
 
+func TestResolveSaveSubagentHistories(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *Config
+		cliExplicit bool
+		cliValue    bool
+		want        bool
+	}{
+		{
+			name:        "explicit flag on wins over config off",
+			cfg:         &Config{SaveSubagentHistories: false},
+			cliExplicit: true,
+			cliValue:    true,
+			want:        true,
+		},
+		{
+			name:        "explicit flag off wins over config on",
+			cfg:         &Config{SaveSubagentHistories: true},
+			cliExplicit: true,
+			cliValue:    false,
+			want:        false,
+		},
+		{
+			name:        "no flag uses config on",
+			cfg:         &Config{SaveSubagentHistories: true},
+			cliExplicit: false,
+			cliValue:    false,
+			want:        true,
+		},
+		{
+			name:        "no flag uses config off",
+			cfg:         &Config{SaveSubagentHistories: false},
+			cliExplicit: false,
+			cliValue:    false,
+			want:        false,
+		},
+		{
+			name:        "no flag and nil config defaults to off",
+			cfg:         nil,
+			cliExplicit: false,
+			cliValue:    false,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveSaveSubagentHistories(tt.cfg, tt.cliExplicit, tt.cliValue); got != tt.want {
+				t.Fatalf("ResolveSaveSubagentHistories() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfig_GetModelForAgent(t *testing.T) {
 	cfg := &Config{
 		Models: []ModelSetting{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -529,26 +529,43 @@ func TestResolveSubagentSettings(t *testing.T) {
 }
 
 func TestResolveSaveSubagentHistories(t *testing.T) {
+	enabled := true
+	disabled := false
 	tests := []struct {
-		name        string
-		cfg         *Config
-		cliExplicit bool
-		cliValue    bool
-		want        bool
+		name            string
+		cfg             *Config
+		cliExplicit     bool
+		cliValue        bool
+		savedPreference *bool
+		want            bool
 	}{
 		{
-			name:        "explicit flag on wins over config off",
-			cfg:         &Config{SaveSubagentHistories: false},
-			cliExplicit: true,
-			cliValue:    true,
-			want:        true,
+			name:            "explicit flag on wins over config off",
+			cfg:             &Config{SaveSubagentHistories: false},
+			cliExplicit:     true,
+			cliValue:        true,
+			savedPreference: &disabled,
+			want:            true,
 		},
 		{
-			name:        "explicit flag off wins over config on",
-			cfg:         &Config{SaveSubagentHistories: true},
-			cliExplicit: true,
-			cliValue:    false,
-			want:        false,
+			name:            "explicit flag off wins over config on",
+			cfg:             &Config{SaveSubagentHistories: true},
+			cliExplicit:     true,
+			cliValue:        false,
+			savedPreference: &enabled,
+			want:            false,
+		},
+		{
+			name:            "saved preference wins over config",
+			cfg:             &Config{SaveSubagentHistories: true},
+			savedPreference: &disabled,
+			want:            false,
+		},
+		{
+			name:            "saved enabled preference wins over config",
+			cfg:             &Config{SaveSubagentHistories: false},
+			savedPreference: &enabled,
+			want:            true,
 		},
 		{
 			name:        "no flag uses config on",
@@ -575,7 +592,7 @@ func TestResolveSaveSubagentHistories(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ResolveSaveSubagentHistories(tt.cfg, tt.cliExplicit, tt.cliValue); got != tt.want {
+			if got := ResolveSaveSubagentHistories(tt.cfg, tt.cliExplicit, tt.cliValue, tt.savedPreference); got != tt.want {
 				t.Fatalf("ResolveSaveSubagentHistories() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/orchestrator/base.go
+++ b/internal/orchestrator/base.go
@@ -26,6 +26,9 @@ type BaseOrchestrator struct {
 	parent   common.Orchestrator
 	children []common.Orchestrator
 
+	// childSeq is a monotonic counter for minting child IDs; guarded by mu
+	childSeq int
+
 	// Running state tracker
 	isRunning   bool
 	pendingMsgs []client.ChatMessage
@@ -440,7 +443,9 @@ func (o *BaseOrchestrator) Registry() *common.ToolRegistry {
 func (o *BaseOrchestrator) Children() []common.Orchestrator {
 	o.mu.RLock()
 	defer o.mu.RUnlock()
-	return o.children
+	out := make([]common.Orchestrator, len(o.children))
+	copy(out, o.children)
+	return out
 }
 
 func (o *BaseOrchestrator) Parent() common.Orchestrator {
@@ -467,6 +472,17 @@ func (o *BaseOrchestrator) Rewind(index int) error {
 		return o.sess.UpdateSessionMetadata()
 	}
 	return nil
+}
+
+// NextChildID atomically mints the next child ID under o.mu. The counter is
+// monotonic and independent of len(children), so concurrent spawns can never
+// produce duplicate IDs.
+func (o *BaseOrchestrator) NextChildID(agentType string) string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	id := fmt.Sprintf("%s-subagent-%d", agentType, o.childSeq)
+	o.childSeq++
+	return id
 }
 
 func (o *BaseOrchestrator) AddChild(child common.Orchestrator) {

--- a/internal/orchestrator/base.go
+++ b/internal/orchestrator/base.go
@@ -476,7 +476,9 @@ func (o *BaseOrchestrator) Rewind(index int) error {
 
 // NextChildID atomically mints the next child ID under o.mu. The counter is
 // monotonic and independent of len(children), so concurrent spawns can never
-// produce duplicate IDs.
+// produce duplicate IDs. The counter is shared across agent types (e.g.,
+// `researcher-subagent-0`, then `coder-subagent-1`), matching the legacy
+// `len(children)` numbering scheme.
 func (o *BaseOrchestrator) NextChildID(agentType string) string {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/internal/orchestrator/base.go
+++ b/internal/orchestrator/base.go
@@ -44,6 +44,10 @@ type BaseOrchestrator struct {
 }
 
 func NewBaseOrchestrator(id string, sess *session.Session, middlewares []common.ToolMiddleware, maxTurns int) *BaseOrchestrator {
+	childSeq := 0
+	if sess != nil {
+		childSeq = sess.SubagentSeq()
+	}
 	return &BaseOrchestrator{
 		id:          id,
 		sess:        sess,
@@ -52,6 +56,7 @@ func NewBaseOrchestrator(id string, sess *session.Session, middlewares []common.
 		ctx:         context.Background(),
 		stopCh:      make(chan struct{}),
 		maxTurns:    maxTurns,
+		childSeq:    childSeq,
 	}
 }
 
@@ -474,17 +479,18 @@ func (o *BaseOrchestrator) Rewind(index int) error {
 	return nil
 }
 
-// NextChildID atomically mints the next child ID under o.mu. The counter is
-// monotonic and independent of len(children), so concurrent spawns can never
-// produce duplicate IDs. The counter is shared across agent types (e.g.,
-// `researcher-subagent-0`, then `coder-subagent-1`), matching the legacy
-// `len(children)` numbering scheme.
-func (o *BaseOrchestrator) NextChildID(agentType string) string {
+// NextChildID atomically reserves and mints the next child ID under o.mu. The
+// counter is shared across agent types (e.g., `researcher-subagent-0`, then
+// `coder-subagent-1`), matching the legacy `len(children)` numbering scheme.
+func (o *BaseOrchestrator) NextChildID(agentType string) (string, error) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	id := fmt.Sprintf("%s-subagent-%d", agentType, o.childSeq)
+	if err := o.sess.UpdateSubagentSeq(o.childSeq + 1); err != nil {
+		return "", fmt.Errorf("failed to reserve child ID: %w", err)
+	}
 	o.childSeq++
-	return id
+	return id, nil
 }
 
 func (o *BaseOrchestrator) AddChild(child common.Orchestrator) {

--- a/internal/orchestrator/base_test.go
+++ b/internal/orchestrator/base_test.go
@@ -141,9 +141,17 @@ func TestNextChildID_FormatAndMonotonic(t *testing.T) {
 
 	var got []string
 	for i := 0; i < 3; i++ {
-		got = append(got, o.NextChildID("researcher"))
+		id, err := o.NextChildID("researcher")
+		if err != nil {
+			t.Fatalf("NextChildID() error = %v", err)
+		}
+		got = append(got, id)
 	}
-	got = append(got, o.NextChildID("coder"))
+	id, err := o.NextChildID("coder")
+	if err != nil {
+		t.Fatalf("NextChildID() error = %v", err)
+	}
+	got = append(got, id)
 
 	want := []string{
 		"researcher-subagent-0",
@@ -178,7 +186,11 @@ func TestNextChildID_Concurrent(t *testing.T) {
 		go func(g int) {
 			defer wg.Done()
 			for i := 0; i < perGoroutine; i++ {
-				id := o.NextChildID("researcher")
+				id, err := o.NextChildID("researcher")
+				if err != nil {
+					t.Errorf("NextChildID() error = %v", err)
+					return
+				}
 				mu.Lock()
 				ids = append(ids, id)
 				mu.Unlock()
@@ -204,5 +216,44 @@ func TestNextChildID_Concurrent(t *testing.T) {
 
 	if n := len(o.Children()); n != goroutines {
 		t.Errorf("Children() length = %d, want %d", n, goroutines)
+	}
+}
+
+func TestNextChildIDPersistsSequenceForResume(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalSessionDir := session.SessionDir
+	session.SessionDir = func() (string, error) { return tmpDir, nil }
+	t.Cleanup(func() { session.SessionDir = originalSessionDir })
+
+	historyPath := filepath.Join(tmpDir, "session-test.json")
+	sess := session.New(nil, historyPath, nil, "", false)
+	sess.SetSubagentMetadata(4, nil)
+	o := NewBaseOrchestrator("parent", sess, nil, 0)
+
+	id, err := o.NextChildID("researcher")
+	if err != nil {
+		t.Fatalf("NextChildID() error = %v", err)
+	}
+	if id != "researcher-subagent-4" {
+		t.Fatalf("NextChildID() = %q, want researcher-subagent-4", id)
+	}
+
+	meta, err := session.LoadSessionMeta("session-test")
+	if err != nil {
+		t.Fatalf("LoadSessionMeta() error = %v", err)
+	}
+	if meta.SubagentSeq != 5 {
+		t.Fatalf("SubagentSeq = %d, want 5", meta.SubagentSeq)
+	}
+
+	resumed := session.New(nil, historyPath, nil, "", false)
+	resumed.SetSubagentMetadata(meta.SubagentSeq, meta.SaveSubagentHistories)
+	resumedOrchestrator := NewBaseOrchestrator("parent", resumed, nil, 0)
+	resumedID, err := resumedOrchestrator.NextChildID("coder")
+	if err != nil {
+		t.Fatalf("resumed NextChildID() error = %v", err)
+	}
+	if resumedID != "coder-subagent-5" {
+		t.Errorf("resumed NextChildID() = %q, want coder-subagent-5", resumedID)
 	}
 }

--- a/internal/orchestrator/base_test.go
+++ b/internal/orchestrator/base_test.go
@@ -2,11 +2,13 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"late/internal/client"
 	"late/internal/common"
 	"late/internal/session"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -131,5 +133,76 @@ func TestBaseOrchestrator_ResetStartsNewConversation(t *testing.T) {
 	}
 	if len(preserved) != 2 {
 		t.Fatalf("saving the new conversation changed original history: %#v", preserved)
+	}
+}
+
+func TestNextChildID_FormatAndMonotonic(t *testing.T) {
+	o := NewBaseOrchestrator("parent", session.New(nil, "", nil, "", false), nil, 0)
+
+	var got []string
+	for i := 0; i < 3; i++ {
+		got = append(got, o.NextChildID("researcher"))
+	}
+	got = append(got, o.NextChildID("coder"))
+
+	want := []string{
+		"researcher-subagent-0",
+		"researcher-subagent-1",
+		"researcher-subagent-2",
+		// The counter is global per parent, NOT per type.
+		"coder-subagent-3",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d IDs, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ID %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestNextChildID_Concurrent(t *testing.T) {
+	o := NewBaseOrchestrator("parent", session.New(nil, "", nil, "", false), nil, 0)
+
+	const goroutines = 64
+	const perGoroutine = 16
+
+	var mu sync.Mutex
+	ids := make([]string, 0, goroutines*perGoroutine)
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				id := o.NextChildID("researcher")
+				mu.Lock()
+				ids = append(ids, id)
+				mu.Unlock()
+			}
+			// Interleave lightweight child registration to ensure concurrent
+			// AddChild calls don't interfere with ID minting.
+			o.AddChild(NewBaseOrchestrator(fmt.Sprintf("dummy-%d", g), nil, nil, 0))
+		}(g)
+	}
+	wg.Wait()
+
+	if len(ids) != goroutines*perGoroutine {
+		t.Fatalf("minted %d IDs, want %d", len(ids), goroutines*perGoroutine)
+	}
+
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate ID minted: %q", id)
+		}
+		seen[id] = struct{}{}
+	}
+
+	if n := len(o.Children()); n != goroutines {
+		t.Errorf("Children() length = %d, want %d", n, goroutines)
 	}
 }

--- a/internal/session/models.go
+++ b/internal/session/models.go
@@ -13,13 +13,15 @@ import (
 
 // SessionMeta represents metadata about a saved session
 type SessionMeta struct {
-	ID             string    `json:"id"`
-	Title          string    `json:"title"` // Short title derived from first user message
-	CreatedAt      time.Time `json:"created_at"`
-	LastUpdated    time.Time `json:"last_updated"`
-	HistoryPath    string    `json:"history_path"`     // Full path to history file
-	LastUserPrompt string    `json:"last_user_prompt"` // Last 100 chars of last user message
-	MessageCount   int       `json:"message_count"`
+	ID                    string    `json:"id"`
+	Title                 string    `json:"title"` // Short title derived from first user message
+	CreatedAt             time.Time `json:"created_at"`
+	LastUpdated           time.Time `json:"last_updated"`
+	HistoryPath           string    `json:"history_path"`     // Full path to history file
+	LastUserPrompt        string    `json:"last_user_prompt"` // Last 100 chars of last user message
+	MessageCount          int       `json:"message_count"`
+	SubagentSeq           int       `json:"subagent_seq"`
+	SaveSubagentHistories *bool     `json:"save_subagent_histories,omitempty"`
 }
 
 // SessionDir returns the directory where session metadata and histories are stored
@@ -169,4 +171,3 @@ func GetLatestSession() (*SessionMeta, error) {
 	// ListSessions returns sessions sorted by LastUpdated ascending (oldest first)
 	return &metas[len(metas)-1], nil
 }
-

--- a/internal/session/models_test.go
+++ b/internal/session/models_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"late/internal/client"
 	"os"
 	"path/filepath"
@@ -62,6 +63,69 @@ func TestSessionMeta(t *testing.T) {
 	_, err = LoadSessionMeta("session-")
 	if err == nil {
 		t.Error("Expected error for ambiguous prefix, got nil")
+	}
+}
+
+func TestSessionMetadataRetainsSubagentState(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) { return tmpDir, nil }
+	t.Cleanup(func() { SessionDir = oldSessionDir })
+
+	saveHistories := false
+	s := New(nil, filepath.Join(tmpDir, "session-test.json"), nil, "", false)
+	s.SetSubagentMetadata(7, &saveHistories)
+	if err := s.AddUserMessage("Hello"); err != nil {
+		t.Fatalf("AddUserMessage() error = %v", err)
+	}
+
+	loaded, err := LoadSessionMeta("session-test")
+	if err != nil {
+		t.Fatalf("LoadSessionMeta() error = %v", err)
+	}
+	if loaded.SubagentSeq != 7 {
+		t.Errorf("SubagentSeq = %d, want 7", loaded.SubagentSeq)
+	}
+	if loaded.SaveSubagentHistories == nil || *loaded.SaveSubagentHistories {
+		t.Errorf("SaveSubagentHistories = %v, want false", loaded.SaveSubagentHistories)
+	}
+}
+
+func TestLoadSessionMetaLegacySubagentState(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) { return tmpDir, nil }
+	t.Cleanup(func() { SessionDir = oldSessionDir })
+
+	metaPath := filepath.Join(tmpDir, "session-legacy.meta.json")
+	if err := os.WriteFile(metaPath, []byte(`{"id":"session-legacy"}`), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	loaded, err := LoadSessionMeta("session-legacy")
+	if err != nil {
+		t.Fatalf("LoadSessionMeta() error = %v", err)
+	}
+	if loaded.SubagentSeq != 0 {
+		t.Errorf("SubagentSeq = %d, want 0", loaded.SubagentSeq)
+	}
+	if loaded.SaveSubagentHistories != nil {
+		t.Errorf("SaveSubagentHistories = %v, want nil", *loaded.SaveSubagentHistories)
+	}
+}
+
+func TestUpdateSubagentSeqRestoresPreviousValueAfterMetadataFailure(t *testing.T) {
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) { return "", errors.New("session directory unavailable") }
+	t.Cleanup(func() { SessionDir = oldSessionDir })
+
+	s := New(nil, "session-test.json", nil, "", false)
+	s.SetSubagentMetadata(4, nil)
+	if err := s.UpdateSubagentSeq(5); err == nil {
+		t.Fatal("UpdateSubagentSeq() error = nil, want metadata save failure")
+	}
+	if s.SubagentSeq() != 4 {
+		t.Errorf("SubagentSeq = %d, want 4", s.SubagentSeq())
 	}
 }
 
@@ -229,4 +293,3 @@ func TestLoadSessionMeta_IgnoresSubagentFolders(t *testing.T) {
 		t.Errorf("Expected nil meta for nonexistent session, got %v", notFound)
 	}
 }
-

--- a/internal/session/models_test.go
+++ b/internal/session/models_test.go
@@ -125,3 +125,108 @@ func TestGetLatestSession(t *testing.T) {
 	}
 }
 
+// setupSubagentFolderFixture swaps SessionDir to a fresh temp dir containing:
+//   - a legacy flat session (history file + meta file) with ID "session-20250101-123456"
+//   - the hierarchical subagent artifacts of another session: a directory
+//     "session-20250102-999999/subagents/" holding subagent history files,
+//     intentionally WITHOUT a meta file of its own
+//
+// SessionDir is restored when the test finishes.
+func setupSubagentFolderFixture(t *testing.T) {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	t.Cleanup(func() { SessionDir = oldSessionDir })
+
+	// Legacy session: flat history file + matching meta
+	const legacyID = "session-20250101-123456"
+	historyPath := filepath.Join(tmpDir, legacyID+".json")
+	history := []client.ChatMessage{{Role: "user", Content: client.TextContent("Hello")}}
+	if err := SaveHistory(historyPath, history); err != nil {
+		t.Fatalf("Failed to save history: %v", err)
+	}
+
+	meta := SessionMeta{
+		ID:          legacyID,
+		Title:       "Legacy Session",
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+		LastUpdated: time.Now(),
+		HistoryPath: historyPath,
+	}
+	if err := SaveSessionMeta(meta); err != nil {
+		t.Fatalf("Failed to save meta: %v", err)
+	}
+
+	// Hierarchical subagent artifacts of another session (no meta file)
+	subagentsDir := filepath.Join(tmpDir, "session-20250102-999999", "subagents")
+	if err := os.MkdirAll(subagentsDir, 0700); err != nil {
+		t.Fatalf("Failed to create subagents dir: %v", err)
+	}
+	for _, name := range []string{"coder-subagent-0.json", "researcher-subagent-1.json"} {
+		if err := os.WriteFile(filepath.Join(subagentsDir, name), []byte("[]"), 0600); err != nil {
+			t.Fatalf("Failed to write subagent history %s: %v", name, err)
+		}
+	}
+}
+
+func TestListSessions_IgnoresSubagentFolders(t *testing.T) {
+	setupSubagentFolderFixture(t)
+
+	metas, err := ListSessions()
+	if err != nil {
+		t.Fatalf("Expected no error from ListSessions, got %v", err)
+	}
+	if len(metas) != 1 {
+		t.Fatalf("Expected exactly 1 session, got %d: %v", len(metas), metas)
+	}
+	if metas[0].ID != "session-20250101-123456" {
+		t.Errorf("Expected session ID 'session-20250101-123456', got %q", metas[0].ID)
+	}
+
+	latest, err := GetLatestSession()
+	if err != nil {
+		t.Fatalf("Expected no error from GetLatestSession, got %v", err)
+	}
+	if latest == nil || latest.ID != "session-20250101-123456" {
+		t.Errorf("Expected latest session 'session-20250101-123456', got %v", latest)
+	}
+}
+
+func TestLoadSessionMeta_IgnoresSubagentFolders(t *testing.T) {
+	setupSubagentFolderFixture(t)
+
+	// Exact match still works
+	exact, err := LoadSessionMeta("session-20250101-123456")
+	if err != nil || exact == nil {
+		t.Fatalf("Failed to load meta exactly: %v", err)
+	}
+	if exact.ID != "session-20250101-123456" {
+		t.Errorf("Expected loaded ID 'session-20250101-123456', got %q", exact.ID)
+	}
+
+	// Prefix matching only the legacy session: the "session-20250102-999999"
+	// directory must be skipped by the prefix scan, introducing no new match or ambiguity
+	byPrefix, err := LoadSessionMeta("session-2025")
+	if err != nil || byPrefix == nil {
+		t.Fatalf("Failed to load meta by prefix: %v", err)
+	}
+	if byPrefix.ID != "session-20250101-123456" {
+		t.Errorf("Expected loaded prefix ID 'session-20250101-123456', got %q", byPrefix.ID)
+	}
+
+	// Nonexistent ID behaves as before: (nil, nil)
+	notFound, err := LoadSessionMeta("nonexistent")
+	if err != nil {
+		t.Fatalf("Expected no error for nonexistent session, got %v", err)
+	}
+	if notFound != nil {
+		t.Errorf("Expected nil meta for nonexistent session, got %v", notFound)
+	}
+}
+

--- a/internal/session/paths.go
+++ b/internal/session/paths.go
@@ -7,10 +7,23 @@ import (
 	"strings"
 )
 
+// isValidPathElement reports whether id is a safe single path element
+// under the sessions directory: non-empty, not "." or "..", and free of
+// path separators (/ and \) and NUL bytes.
+func isValidPathElement(id string) bool {
+	if id == "" || id == "." || id == ".." {
+		return false
+	}
+	return !strings.ContainsAny(id, "/\\") && !strings.ContainsRune(id, 0)
+}
+
 // SubagentHistoryDir returns the directory holding a session's subagent
 // histories: <sessionsDir>/<sessionID>/subagents. It is created lazily by
 // SaveHistory (MkdirAll 0700), so this helper does not create it.
 func SubagentHistoryDir(sessionID string) (string, error) {
+	if !isValidPathElement(sessionID) {
+		return "", fmt.Errorf("invalid session ID: %q", sessionID)
+	}
 	sessionsDir, err := SessionDir()
 	if err != nil {
 		return "", err
@@ -21,6 +34,12 @@ func SubagentHistoryDir(sessionID string) (string, error) {
 // SubagentHistoryPath returns the full path of a subagent history file:
 // <sessionsDir>/<parentSessionID>/subagents/<childID>.json.
 func SubagentHistoryPath(parentSessionID, childID string) (string, error) {
+	if !isValidPathElement(parentSessionID) {
+		return "", fmt.Errorf("invalid session ID: %q", parentSessionID)
+	}
+	if !isValidPathElement(childID) {
+		return "", fmt.Errorf("invalid child ID: %q", childID)
+	}
 	dir, err := SubagentHistoryDir(parentSessionID)
 	if err != nil {
 		return "", err
@@ -31,9 +50,10 @@ func SubagentHistoryPath(parentSessionID, childID string) (string, error) {
 // RemoveSessionFolder deletes a session's folder (containing its subagent
 // histories) if it exists. Flat files <sessionID>.json / .meta.json are
 // distinct names and are never touched. Returns nil when the folder does
-// not exist (legacy sessions) or for IDs containing path separators.
+// not exist (legacy sessions) or for unsafe IDs (empty, ".", "..", path
+// separators, NUL bytes).
 func RemoveSessionFolder(sessionID string) error {
-	if sessionID == "" || strings.ContainsAny(sessionID, "/\\") {
+	if !isValidPathElement(sessionID) {
 		return nil
 	}
 	sessionsDir, err := SessionDir()

--- a/internal/session/paths.go
+++ b/internal/session/paths.go
@@ -1,0 +1,44 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SubagentHistoryDir returns the directory holding a session's subagent
+// histories: <sessionsDir>/<sessionID>/subagents. It is created lazily by
+// SaveHistory (MkdirAll 0700), so this helper does not create it.
+func SubagentHistoryDir(sessionID string) (string, error) {
+	sessionsDir, err := SessionDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(sessionsDir, sessionID, "subagents"), nil
+}
+
+// SubagentHistoryPath returns the full path of a subagent history file:
+// <sessionsDir>/<parentSessionID>/subagents/<childID>.json.
+func SubagentHistoryPath(parentSessionID, childID string) (string, error) {
+	dir, err := SubagentHistoryDir(parentSessionID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, childID+".json"), nil
+}
+
+// RemoveSessionFolder deletes a session's folder (containing its subagent
+// histories) if it exists. Flat files <sessionID>.json / .meta.json are
+// distinct names and are never touched. Returns nil when the folder does
+// not exist (legacy sessions) or for IDs containing path separators.
+func RemoveSessionFolder(sessionID string) error {
+	if sessionID == "" || strings.ContainsAny(sessionID, "/\\") {
+		return nil
+	}
+	sessionsDir, err := SessionDir()
+	if err != nil {
+		return fmt.Errorf("failed to get session directory: %w", err)
+	}
+	return os.RemoveAll(filepath.Join(sessionsDir, sessionID))
+}

--- a/internal/session/paths_test.go
+++ b/internal/session/paths_test.go
@@ -1,0 +1,138 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSubagentHistoryPath(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "late-session-paths-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	defer func() { SessionDir = oldSessionDir }()
+
+	const sessionID = "session-20250101-123456"
+	const childID = "researcher-subagent-0"
+
+	wantDir := filepath.Join(tmpDir, sessionID, "subagents")
+	gotDir, err := SubagentHistoryDir(sessionID)
+	if err != nil {
+		t.Fatalf("SubagentHistoryDir returned error: %v", err)
+	}
+	if gotDir != wantDir {
+		t.Errorf("Expected SubagentHistoryDir %q, got %q", wantDir, gotDir)
+	}
+
+	wantPath := filepath.Join(wantDir, childID+".json")
+	gotPath, err := SubagentHistoryPath(sessionID, childID)
+	if err != nil {
+		t.Fatalf("SubagentHistoryPath returned error: %v", err)
+	}
+	if gotPath != wantPath {
+		t.Errorf("Expected SubagentHistoryPath %q, got %q", wantPath, gotPath)
+	}
+
+	// Neither helper must pre-create directories.
+	if _, err := os.Stat(filepath.Join(tmpDir, sessionID)); !os.IsNotExist(err) {
+		t.Errorf("Expected no pre-created %q folder, got stat err=%v", sessionID, err)
+	}
+}
+
+func TestRemoveSessionFolder_RemovesFolderKeepsFlatFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "late-session-rmtest-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	defer func() { SessionDir = oldSessionDir }()
+
+	const sessionID = "session-X"
+	subagentsDir := filepath.Join(tmpDir, sessionID, "subagents")
+	if err := os.MkdirAll(subagentsDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	childPath := filepath.Join(subagentsDir, "coder-subagent-0.json")
+	if err := os.WriteFile(childPath, []byte("[]"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	flatJSON := filepath.Join(tmpDir, sessionID+".json")
+	flatMeta := filepath.Join(tmpDir, sessionID+".meta.json")
+	if err := os.WriteFile(flatJSON, []byte("[]"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flatMeta, []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveSessionFolder(sessionID); err != nil {
+		t.Fatalf("RemoveSessionFolder returned error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, sessionID)); !os.IsNotExist(err) {
+		t.Errorf("Expected %q folder to be removed, got stat err=%v", sessionID, err)
+	}
+	if _, err := os.Stat(childPath); !os.IsNotExist(err) {
+		t.Errorf("Expected subagent history %q to be removed, got stat err=%v", childPath, err)
+	}
+	if _, err := os.Stat(flatJSON); err != nil {
+		t.Errorf("Expected flat file %q to survive, got stat err=%v", flatJSON, err)
+	}
+	if _, err := os.Stat(flatMeta); err != nil {
+		t.Errorf("Expected flat file %q to survive, got stat err=%v", flatMeta, err)
+	}
+}
+
+func TestRemoveSessionFolder_NoopForMissingAndUnsafeIDs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "late-session-noop-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	defer func() { SessionDir = oldSessionDir }()
+
+	// Never-created ID: no error, nothing deleted.
+	if err := RemoveSessionFolder("session-does-not-exist"); err != nil {
+		t.Errorf("Expected nil error for missing session ID, got %v", err)
+	}
+
+	// Unsafe IDs: no error, nothing deleted, no panic.
+	for _, unsafeID := range []string{"", "../evil", "a/b", "..\\windows-evil"} {
+		if err := RemoveSessionFolder(unsafeID); err != nil {
+			t.Errorf("Expected nil error for unsafe session ID %q, got %v", unsafeID, err)
+		}
+		if _, err := os.Stat(filepath.Join(tmpDir, "..", "evil")); !os.IsNotExist(err) {
+			t.Errorf("Expected no deletion outside temp dir for %q, got stat err=%v", unsafeID, err)
+		}
+	}
+
+	// The temp dir itself must still exist with an empty listing.
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to read temp dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected temp dir to remain empty, found %d entries: %v", len(entries), entries)
+	}
+}

--- a/internal/session/paths_test.go
+++ b/internal/session/paths_test.go
@@ -118,7 +118,7 @@ func TestRemoveSessionFolder_NoopForMissingAndUnsafeIDs(t *testing.T) {
 	}
 
 	// Unsafe IDs: no error, nothing deleted, no panic.
-	for _, unsafeID := range []string{"", "../evil", "a/b", "..\\windows-evil"} {
+	for _, unsafeID := range []string{"", ".", "..", "../evil", "a/b", "..\\windows-evil"} {
 		if err := RemoveSessionFolder(unsafeID); err != nil {
 			t.Errorf("Expected nil error for unsafe session ID %q, got %v", unsafeID, err)
 		}
@@ -134,5 +134,66 @@ func TestRemoveSessionFolder_NoopForMissingAndUnsafeIDs(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("Expected temp dir to remain empty, found %d entries: %v", len(entries), entries)
+	}
+}
+
+func TestSubagentHistoryPathRejectsUnsafeIDs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "late-session-unsafe-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	defer func() { SessionDir = oldSessionDir }()
+
+	for _, unsafeID := range []string{"", ".", "..", "../x", "a/b"} {
+		if _, err := SubagentHistoryDir(unsafeID); err == nil {
+			t.Errorf("Expected error from SubagentHistoryDir for unsafe session ID %q, got nil", unsafeID)
+		}
+		if _, err := SubagentHistoryPath(unsafeID, "coder"); err == nil {
+			t.Errorf("Expected error from SubagentHistoryPath for unsafe session ID %q, got nil", unsafeID)
+		}
+	}
+
+	if _, err := SubagentHistoryPath("session-x", ".."); err == nil {
+		t.Errorf("Expected error from SubagentHistoryPath for unsafe child ID %q, got nil", "..")
+	}
+
+	// Nothing may have been created on disk.
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to read temp dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected temp dir to remain empty, found %d entries: %v", len(entries), entries)
+	}
+}
+
+func TestSubagentHistoryPathValidInputs(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "late-session-valid-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	defer func() { SessionDir = oldSessionDir }()
+
+	gotPath, err := SubagentHistoryPath("session-x", "coder-subagent-0")
+	if err != nil {
+		t.Fatalf("SubagentHistoryPath returned error: %v", err)
+	}
+	wantPath := filepath.Join(tmpDir, "session-x", "subagents", "coder-subagent-0.json")
+	if gotPath != wantPath {
+		t.Errorf("Expected SubagentHistoryPath %q, got %q", wantPath, gotPath)
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -15,14 +15,16 @@ import (
 
 // Session manages the chat state and interacts with the LLM client.
 type Session struct {
-	clientMu     sync.RWMutex
-	client       *client.Client
-	HistoryPath  string
-	History      []client.ChatMessage
-	systemPrompt string
-	useTools     bool
-	skipMetadata bool // when true, no top-level .meta.json sidecar is written (subagents)
-	Registry     *tool.Registry
+	clientMu              sync.RWMutex
+	client                *client.Client
+	HistoryPath           string
+	History               []client.ChatMessage
+	systemPrompt          string
+	useTools              bool
+	skipMetadata          bool // when true, no top-level .meta.json sidecar is written (subagents)
+	subagentSeq           int
+	saveSubagentHistories *bool
+	Registry              *tool.Registry
 }
 
 func New(c *client.Client, historyPath string, history []client.ChatMessage, systemPrompt string, useTools bool) *Session {
@@ -44,6 +46,38 @@ func NewSubagentSession(c *client.Client, historyPath string, history []client.C
 	s := New(c, historyPath, history, systemPrompt, true)
 	s.skipMetadata = true
 	return s
+}
+
+// SetSubagentMetadata initializes root-session state that must survive resume.
+func (s *Session) SetSubagentMetadata(seq int, saveHistories *bool) {
+	s.subagentSeq = seq
+	if saveHistories == nil {
+		s.saveSubagentHistories = nil
+		return
+	}
+	value := *saveHistories
+	s.saveSubagentHistories = &value
+}
+
+// SubagentSeq returns the next sequence number reserved for a child session.
+func (s *Session) SubagentSeq() int {
+	return s.subagentSeq
+}
+
+// UpdateSubagentSeq durably advances the next child sequence before a child
+// history path is created. In-memory and subagent sessions retain their
+// existing behavior because neither writes root session metadata.
+func (s *Session) UpdateSubagentSeq(seq int) error {
+	previous := s.subagentSeq
+	s.subagentSeq = seq
+	if s.skipMetadata || s.HistoryPath == "" {
+		return nil
+	}
+	if err := s.UpdateSessionMetadata(); err != nil {
+		s.subagentSeq = previous
+		return err
+	}
+	return nil
 }
 
 // ExecuteTool executes a tool call and returns the response as a string.
@@ -282,13 +316,15 @@ func (s *Session) GenerateSessionMeta() SessionMeta {
 	id = strings.TrimSuffix(id, ".json")
 
 	return SessionMeta{
-		ID:             id,
-		Title:          title,
-		CreatedAt:      time.Now(),
-		LastUpdated:    time.Now(),
-		HistoryPath:    s.HistoryPath,
-		LastUserPrompt: lastPrompt,
-		MessageCount:   len(s.History),
+		ID:                    id,
+		Title:                 title,
+		CreatedAt:             time.Now(),
+		LastUpdated:           time.Now(),
+		HistoryPath:           s.HistoryPath,
+		LastUserPrompt:        lastPrompt,
+		MessageCount:          len(s.History),
+		SubagentSeq:           s.subagentSeq,
+		SaveSubagentHistories: s.saveSubagentHistories,
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -21,6 +21,7 @@ type Session struct {
 	History      []client.ChatMessage
 	systemPrompt string
 	useTools     bool
+	skipMetadata bool // when true, no top-level .meta.json sidecar is written (subagents)
 	Registry     *tool.Registry
 }
 
@@ -33,6 +34,16 @@ func New(c *client.Client, historyPath string, history []client.ChatMessage, sys
 		useTools:     useTools,
 		Registry:     tool.NewRegistry(),
 	}
+}
+
+// NewSubagentSession creates a session for a subagent. History is persisted
+// to historyPath when non-empty (in-memory otherwise), but the session never
+// writes a top-level .meta.json sidecar, keeping the shared sessions
+// directory free of subagent entries.
+func NewSubagentSession(c *client.Client, historyPath string, history []client.ChatMessage, systemPrompt string) *Session {
+	s := New(c, historyPath, history, systemPrompt, true)
+	s.skipMetadata = true
+	return s
 }
 
 // ExecuteTool executes a tool call and returns the response as a string.
@@ -283,6 +294,9 @@ func (s *Session) GenerateSessionMeta() SessionMeta {
 
 // UpdateSessionMetadata updates the session metadata file
 func (s *Session) UpdateSessionMetadata() error {
+	if s.skipMetadata {
+		return nil
+	}
 	meta := s.GenerateSessionMeta()
 	return SaveSessionMeta(meta)
 }
@@ -326,7 +340,7 @@ func (s *Session) saveAndNotify() error {
 		return nil
 	}
 	if s.HistoryPath == "" {
-		return nil // Skip saving if no path provided (e.g., subagents)
+		return nil // Skip saving if no path provided (e.g., in-memory sessions, subagents without history opt-in)
 	}
 	if err := SaveHistory(s.HistoryPath, s.History); err != nil {
 		return err

--- a/internal/session/subagent_session_test.go
+++ b/internal/session/subagent_session_test.go
@@ -1,0 +1,69 @@
+package session
+
+import (
+	"encoding/json"
+	"late/internal/client"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSubagentSession_SavesHistoryWithoutMeta(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	t.Cleanup(func() { SessionDir = oldSessionDir })
+
+	historyPath := filepath.Join(tmpDir, "session-test", "subagents", "coder-subagent-0.json")
+	s := NewSubagentSession(nil, historyPath, nil, "sp")
+
+	if err := s.AddUserMessage("hello"); err != nil {
+		t.Fatalf("AddUserMessage returned error: %v", err)
+	}
+
+	// History must be persisted to the nested subagent path.
+	data, err := os.ReadFile(historyPath)
+	if err != nil {
+		t.Fatalf("Expected subagent history file %q to exist, got: %v", historyPath, err)
+	}
+	var history []client.ChatMessage
+	if err := json.Unmarshal(data, &history); err != nil {
+		t.Fatalf("Failed to unmarshal subagent history: %v", err)
+	}
+	if len(history) == 0 {
+		t.Errorf("Expected non-empty subagent history, got 0 messages")
+	}
+
+	// No top-level .meta.json sidecar must be written for subagents.
+	metaPath := filepath.Join(tmpDir, "coder-subagent-0.meta.json")
+	if _, err := os.Stat(metaPath); !os.IsNotExist(err) {
+		t.Errorf("Expected no top-level meta file %q, got stat err=%v", metaPath, err)
+	}
+}
+
+func TestRegularSession_StillWritesMeta(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Mock SessionDir
+	oldSessionDir := SessionDir
+	SessionDir = func() (string, error) {
+		return tmpDir, nil
+	}
+	t.Cleanup(func() { SessionDir = oldSessionDir })
+
+	historyPath := filepath.Join(tmpDir, "session-test.json")
+	s := New(nil, historyPath, nil, "sp", true)
+
+	if err := s.AddUserMessage("hello"); err != nil {
+		t.Fatalf("AddUserMessage returned error: %v", err)
+	}
+
+	metaPath := filepath.Join(tmpDir, "session-test.meta.json")
+	if _, err := os.Stat(metaPath); err != nil {
+		t.Errorf("Expected top-level meta file %q to exist, got stat err=%v", metaPath, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #109 

Introduces **opt-in persistence** for subagent conversation histories, restructures sessions into a hierarchical on-disk layout, and fixes a **thread-unsafe subagent-ID generation** bug that would silently cause file collisions under concurrent spawns.

## Changes

### 1. Hierarchical Storage Layout (`internal/session/paths.go`)

When persistence is enabled, subagent histories are written under the parent session's folder (`<sessions>/<sessionID>/subagents/<childID>.json`). Parent `.json` / `.meta.json` files stay flat and unchanged.

- `SubagentHistoryDir`, `SubagentHistoryPath`, and `RemoveSessionFolder` manage the subagent tree
- `isValidPathElement` rejects `.`, `..`, path separators, and NUL bytes to prevent directory traversal
- `late session delete` also cleans up the subagent folder alongside the parent session

### 2. Thread-Safe ID Generation (`internal/orchestrator/base.go`)

- Added a mutex-protected `NextChildID(typePrefix string)` counter on `BaseOrchestrator`
- `NewSubagentOrchestrator` now mints the child ID **before** creating the session, so the path is known at construction time
- The old lockless `len(parent.Children())` fallback is removed entirely; a subagent **must** have a `*BaseOrchestrator` parent

### 3. Opt-In Persistence (`cmd/late/main.go`, `internal/config/config.go`)

- **CLI flag:** `--save-subagent-histories` (default `false`)
- **Config file field:** `save_subagent_histories` (JSON)
- **Resolution order:** explicit CLI flag > config file > default (`false`)
- There is deliberately **no environment-variable override** — the user must consciously opt in per run or per config

`effectiveSessionID` is derived from the actual history path so resumed sessions reuse their original folder.

### 4. Defensive Hardening

- **Unsafe session IDs:** if `effectiveSessionID` is empty or unsafe, subagent histories fall back to in-memory instead of writing outside the session tree

## Testing

7 test files updated (~1,128 lines) covering:
- subagent orchestrator construction with/without persistence and parent-type enforcement
- path validation (`..`, separators, NUL), resolution, and folder cleanup
- `NextChildID` counter increment and concurrency safety
- config precedence rules and CLI flag wiring
- `deriveEffectiveSessionID` edge cases and session-delete cleanup path

## Backwards Compatibility

- Default behavior is unchanged: without the flag or config field, subagents stay in-memory and legacy flat sessions continue to work
- **No automatic migration** of existing flat files is performed (out of scope)

---

### Contributor License Agreement (CLA)
To accept your code, we legally need you to agree to our CLA so we can maintain the project's Business Source License (BSL) and future open-source transitions.

- [x] **By checking this box, I confirm that I have read and agree to the terms of the [CLA.md](https://github.com/mlhher/late/blob/main/.github/CLA.md) in this repository.** *(To check the box, put an `x` between the brackets like this: `[x]`)*